### PR TITLE
feat: add support for `jsconfig.json`

### DIFF
--- a/.changeset/neat-glasses-carry.md
+++ b/.changeset/neat-glasses-carry.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": minor
+---
+
+feat: add support for `jsconfig.json`

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test": "run-p test:*",
     "test:multipleEslintrcs": "eslint --ext ts,tsx tests/multipleEslintrcs",
     "test:multipleTsconfigs": "eslint --ext ts,tsx tests/multipleTsconfigs",
+    "test:withJsconfig": "eslint --ext js tests/withJsconfig",
     "test:withJsExtension": "node tests/withJsExtension/test.js && eslint --ext ts,tsx tests/withJsExtension",
     "test:withPaths": "eslint --ext ts,tsx tests/withPaths",
     "test:withPathsAndNestedBaseUrl": "eslint --ext ts,tsx tests/withPathsAndNestedBaseUrl",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   ResolverFactory,
 } from 'enhanced-resolve'
 import { createPathsMatcher, getTsconfig } from 'get-tsconfig'
+import type { TsConfigResult } from 'get-tsconfig'
 import isCore from 'is-core-module'
 import isGlob from 'is-glob'
 import { createSyncFn } from 'synckit'
@@ -333,7 +334,15 @@ function initMappers(options: InternalResolverOptions) {
   ]
 
   mappers = projectPaths.map(projectPath => {
-    const tsconfigResult = getTsconfig(projectPath)
+    let tsconfigResult: TsConfigResult | null
+
+    if (isFile(projectPath)) {
+      const { dir, base } = path.parse(projectPath)
+      tsconfigResult = getTsconfig(dir, base)
+    } else {
+      tsconfigResult = getTsconfig(projectPath)
+    }
+
     return tsconfigResult && createPathsMatcher(tsconfigResult)
   })
 

--- a/tests/withJsconfig/.eslintrc.cjs
+++ b/tests/withJsconfig/.eslintrc.cjs
@@ -1,0 +1,5 @@
+const path = require('path')
+
+const configPath = path.join(__dirname, 'jsconfig.json')
+
+module.exports = require('../baseEslintConfig.cjs')(configPath)

--- a/tests/withJsconfig/importee.js
+++ b/tests/withJsconfig/importee.js
@@ -1,0 +1,1 @@
+export default 'importee'

--- a/tests/withJsconfig/index.js
+++ b/tests/withJsconfig/index.js
@@ -1,0 +1,2 @@
+// import using jsconfig.json path mapping
+import '#/importee'

--- a/tests/withJsconfig/jsconfig.json
+++ b/tests/withJsconfig/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "#/*": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
close #73 

tl;dr - this handles the case of `project: "path/to/jsconfig.json"` without breaking `project: "/path/to/dir"`.

### Context: `get-tsconfig` behaviour

If a path other than `tsconfig.json` is used, `getTsconfig` requires that the first argument is a directory and the second argument is a path.

The second argument to `getTsconfig` must not be a directory, otherwise it will try to read it as a file, resulting in an error.

### Current behaviour

The given `project` paths, or the resulting paths from globs, are passed as the first and only argument to `getTsconfig`.

### Changes

In the case that the given `project` path is a file, or a glob results in a file, its parent directory will be passed as the first argument to `getTsconfig` and its base name will be the second argument.
This fixes passing full filenames other than `tsconfig.json`, ex. `jsconfig.json`.

In the case that a given `project` path is a directory, or a glob results in a directory, the full path will be passed as the first and only argument to `getTsconfig`.
This distinction is necessary, since if the base name of a directory is passed as the second argument it will result in an error.