### PR TITLE
perf: add filesystem caching support

### DIFF
--- a/.changeset/nasty-points-speak.md
+++ b/.changeset/nasty-points-speak.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+perf: add filesystem caching support

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export function resolve(
       extensions: options?.extensions ?? defaultExtensions,
       extensionAlias: options?.extensionAlias ?? defaultExtensionAlias,
       mainFields: options?.mainFields ?? defaultMainFields,
-      fileSystem: new CachedInputFileSystem(fileSystem, 5000),
+      fileSystem: new CachedInputFileSystem(fileSystem, 5 * 1000),
       useSyncFileSystemCalls: true,
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ export function resolve(
       extensions: options?.extensions ?? defaultExtensions,
       extensionAlias: options?.extensionAlias ?? defaultExtensionAlias,
       mainFields: options?.mainFields ?? defaultMainFields,
-      fileSystem: new CachedInputFileSystem(fileSystem, 500),
+      fileSystem: new CachedInputFileSystem(fileSystem, 5000),
       useSyncFileSystemCalls: true,
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import debug from 'debug'
 import {
   FileSystem,
+  CachedInputFileSystem,
   ResolveOptions,
   Resolver,
   ResolverFactory,
@@ -113,6 +114,7 @@ const fileSystem = fs as FileSystem
 const JS_EXT_PATTERN = /\.(?:[cm]js|jsx?)$/
 const RELATIVE_PATH_PATTERN = /^\.{1,2}(?:\/.*)?$/
 
+let previousOptions: TsResolverOptions | null | undefined
 let cachedOptions: InternalResolverOptions | undefined
 
 let mappersCachedOptions: InternalResolverOptions
@@ -135,14 +137,15 @@ export function resolve(
   found: boolean
   path?: string | null
 } {
-  if (!cachedOptions || cachedOptions !== options) {
+  if (!cachedOptions || previousOptions !== options) {
+    previousOptions = options
     cachedOptions = {
       ...options,
       conditionNames: options?.conditionNames ?? defaultConditionNames,
       extensions: options?.extensions ?? defaultExtensions,
       extensionAlias: options?.extensionAlias ?? defaultExtensionAlias,
       mainFields: options?.mainFields ?? defaultMainFields,
-      fileSystem,
+      fileSystem: new CachedInputFileSystem(fileSystem, 500),
       useSyncFileSystemCalls: true,
     }
   }


### PR DESCRIPTION
Adds caching to the enhanced resolve as described in the docs https://github.com/webpack/enhanced-resolve#creating-a-resolver

On https://github.com/thatsmydoing/eslint-import-resolver-typescript-158, this reduces the time from 27 seconds down to 9 seconds but that's still pretty far from 2.7.1 which takes less than 3 seconds.