### PR TITLE
perf: disable `throwIfNoEntry` on Node 14+

### DIFF
--- a/.changeset/cyan-parrots-act.md
+++ b/.changeset/cyan-parrots-act.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+perf: disable `throwIfNoEntry` on Node 14+

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,8 +243,9 @@ function removeQuerystring(id: string) {
 
 const isFile = (path?: string | undefined): path is string => {
   try {
-    return !!path && fs.statSync(path).isFile()
+    return !!(path && fs.statSync(path, { throwIfNoEntry: false })?.isFile())
   } catch {
+    // Node 12 does not support throwIfNoEntry.
     return false
   }
 }


### PR DESCRIPTION
Resolves #181 

Kept `try...catch` block as [ESLint still keeps support on v12.22.0+](https://github.com/eslint/eslint#installation-and-usage) and `throwIfNoEntry` is not supported until Node 14 LTS.
