### PR TITLE
chore(package): remove node 12 from engines field

### DIFF
--- a/.changeset/fluffy-poets-applaud.md
+++ b/.changeset/fluffy-poets-applaud.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+chore(package): remove node 12 from engines field

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "packageManager": "pnpm@7.12.2",
   "engines": {
-    "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "main": "lib/index.cjs",
   "module": "lib/index.js",


### PR DESCRIPTION
importing node:fs and node:path in commonjs does not work in node 12 dependency synckit also does no longer support node 12

resolves #192 