### PR TITLE
perf: avoid unnecessary `fs.statSync` calls

### DIFF
--- a/.changeset/mean-seals-tease.md
+++ b/.changeset/mean-seals-tease.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+Only try to resolve a module directory when we know that the path is a directory. This can lead to a 15% speedup on projects with many files.

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,26 @@ function getMappedPath(
         ]),
       )
       .flat(2)
-      .filter(mappedPath => isFile(mappedPath) || isModule(mappedPath))
+      .filter(mappedPath => {
+        if (mappedPath === undefined) {
+          return false
+        }
+
+        try {
+          const stat = fs.statSync(mappedPath, { throwIfNoEntry: false })
+          if (stat === undefined) return false
+          if (stat.isFile()) return true
+
+          // Maybe this is a module dir?
+          if (stat.isDirectory()) {
+            return isModule(mappedPath)
+          }
+        } catch {
+          return false
+        }
+
+        return false
+      })
   }
 
   if (retry && paths.length === 0) {


### PR DESCRIPTION
Only resolve a module dir when we now that the mapped path is a directory. This improves linting time by about 18% in projects with lots of files.

The reason for the speedup is an accidental overhead in the callback of the filter function.

https://github.com/import-js/eslint-import-resolver-typescript/blob/46de0e8fccfc0460f336c4006f9df0263f7394c9/src/index.ts#L290 

There we check if something resolves to file, and if not we'll check if it is a module directory. But in 99% of cases we'll be resolving file extensions in this callback. If `/foo/bar/package.json` is not a file, then it's very unlikely that `/foo/bar.ts/package.json` will be, unless `/foo/bar.ts` is a directory. Before this PR we'd check for the latter regardless which lead to an `ENOTDIR` error being thrown. The mere overhead of constantly throwing this error is where most of the time was spent in the traces I looked at.

Overall the logic can be improved further, but I think for now this PR reduces most of the overhead of calling into `fs.statSync`.

Before:

<img width="391" alt="Screenshot 2023-01-10 at 15 09 11" src="https://user-images.githubusercontent.com/1062408/211573096-7c2788f9-a9ce-4fcf-82b7-dbc73b144488.png">

After:

<img width="390" alt="Screenshot 2023-01-10 at 15 09 16" src="https://user-images.githubusercontent.com/1062408/211573134-ca84ef84-03b9-4b96-8591-ae6917cf36e3.png">