### PR TITLE
fix: check if cwd changed to bust mapper cache

### DIFF
--- a/.changeset/rich-icons-hope.md
+++ b/.changeset/rich-icons-hope.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+fix: check if cwd changed to bust mapper cache

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,8 @@ let previousOptionsHash: string
 let optionsHash: string
 let cachedOptions: InternalResolverOptions | undefined
 
+let prevCwd: string
+
 let mappersCachedOptions: InternalResolverOptions
 let mappers: Array<((specifier: string) => string[]) | null> | undefined
 
@@ -347,9 +349,14 @@ function getMappedPath(
 }
 
 function initMappers(options: InternalResolverOptions) {
-  if (mappers && mappersCachedOptions === options) {
+  if (
+    mappers &&
+    mappersCachedOptions === options &&
+    prevCwd === process.cwd()
+  ) {
     return
   }
+  prevCwd = process.cwd()
 
   const configPaths =
     typeof options.project === 'string'


### PR DESCRIPTION
Fixes https://github.com/import-js/eslint-import-resolver-typescript/issues/217