### PR TITLE
Fix peerDependency warning when used with eslint-plugin-i

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,16 @@
   },
   "peerDependencies": {
     "eslint": "*",
-    "eslint-plugin-import": "*"
+    "eslint-plugin-import": "*",
+    "eslint-plugin-i": "*"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-import": {
+      "optional": true
+    },
+    "eslint-plugin-i": {
+      "optional": true
+    }
   },
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
Fixes the following warning e.g. in Yarn:

> ➤ YN0002: │ my-project@workspace:. doesn't provide eslint-plugin-import (p2dacd), requested by eslint-import-resolver-typescript

The downside is that in order to support "either or", we need to make both eslint-plugin-import and eslint-plugin-i optional peerDependencies.