### PR TITLE
docs(readme): add a warning for eslint-plugin-i npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ pnpm i -D eslint-plugin-import eslint-import-resolver-typescript
 yarn add -D eslint-plugin-import eslint-import-resolver-typescript
 ```
 
+**Important when using `eslint-plugin-i` and `npm`**: Use `npm i -D eslint-plugin-import@eslint-plugin-i@latest eslint-import-resolver-typescript`, or you will end up with both `eslint-plugin-import` and `eslint-plugin-i` in your node_modules.
+
 ## Configuration
 
 Add the following to your `.eslintrc` config:


### PR DESCRIPTION
coming from https://github.com/import-js/eslint-import-resolver-typescript/pull/243#issuecomment-1814819670, to make sure everyone is aware of how to prevent having both modules in the node_modules folder.