### PR TITLE
feat: add bun built-in modules support

### DIFF
--- a/.changeset/purple-planes-grin.md
+++ b/.changeset/purple-planes-grin.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': minor
+---
+
+feat: add bun built-in module support

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prepare": "simple-git-hooks",
     "release": "changeset publish",
     "test": "run-p 'test:*'",
+    "test:bun": "eslint --ext ts,tsx tests/bun",
     "test:multipleEslintrcs": "eslint --ext ts,tsx tests/multipleEslintrcs",
     "test:multipleTsconfigs": "eslint --ext ts,tsx tests/multipleTsconfigs",
     "test:withJsExtension": "node tests/withJsExtension/test.js && eslint --ext ts,tsx tests/withJsExtension",

--- a/tests/bun/.eslintrc.cjs
+++ b/tests/bun/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../baseEslintConfig.cjs')(__dirname)

--- a/tests/bun/index.ts
+++ b/tests/bun/index.ts
@@ -1,0 +1,5 @@
+/* eslint-disable */
+// @ts-expect-error
+import { Database } from 'bun:sqlite'
+
+export default new Database()

--- a/tests/bun/tsconfig.json
+++ b/tests/bun/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "files": ["index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,6 @@
     "module": "Node16",
     "outDir": "./lib"
   },
-  "include": ["./src", "./shim.d.ts"]
+  "include": ["./src", "./shim.d.ts"],
+  "exclude": ["./node_modules/bun-types/**/*"]
 }


### PR DESCRIPTION
Add [bun](https://bun.sh/) support (so `import { Database } from 'bun:sqlite'`) won't trigger `import/no-unresolved`.

There are no existing `is-bun-modules`, so a naive solution is to locate `bun-types` and find all `declare module`.

The PR is still in draft, as the test requires `bun-types` to be installed, which will pollute the globals.

