### PR TITLE
Allow either import or import-x plugin as a peer dependency

### DIFF
--- a/.changeset/purple-buttons-lay.md
+++ b/.changeset/purple-buttons-lay.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+Allow either eslint-plugin-import-x or eslint-plugin-import plugin as a peer dependency.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,12 @@
   },
   "peerDependencies": {
     "eslint": "*",
-    "eslint-plugin-import": "*"
+    "eslint-plugin-import": "*",
+    "eslint-plugin-import-x": "*"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-import": { "optional": true },
+    "eslint-plugin-import-x": { "optional": true }
   },
   "dependencies": {
     "debug": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,12 @@
     "eslint-plugin-import-x": "*"
   },
   "peerDependenciesMeta": {
-    "eslint-plugin-import": { "optional": true },
-    "eslint-plugin-import-x": { "optional": true }
+    "eslint-plugin-import": {
+      "optional": true
+    },
+    "eslint-plugin-import-x": {
+      "optional": true
+    }
   },
   "dependencies": {
     "debug": "^4.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,6 +6145,12 @@ __metadata:
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
+    eslint-plugin-import-x: "*"
+  peerDependenciesMeta:
+    eslint-plugin-import:
+      optional: true
+    eslint-plugin-import-x:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes #293 

The PR marks both `import` and `import-x` plugins as optional peer dependencies, thus disables the warning on missing `import` when you're using `import-x` instead.