### PR TITLE
chore(deps): remove `is-core-module` dependency

### DIFF
--- a/.changeset/spotty-grapes-draw.md
+++ b/.changeset/spotty-grapes-draw.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+chore(deps): remove `is-core-module` dependency

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-module-utils": "^2.8.1",
     "fast-glob": "^3.3.2",
     "get-tsconfig": "^4.7.5",
-    "is-core-module": "^2.13.1",
     "is-glob": "^4.0.3"
   },
   "devDependencies": {
@@ -91,7 +90,6 @@
     "@mozilla/glean": "^3.0.0",
     "@pkgr/rollup": "^4.1.3",
     "@types/debug": "^4.1.12",
-    "@types/is-core-module": "^2.2.2",
     "@types/is-glob": "^4.0.4",
     "@types/node": "^18.19.39",
     "@types/unist": "^2.0.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,11 +123,7 @@ const digestHashObject = (value: object | null | undefined) =>
  * versions of Node.js, we can use module.isBuiltin instead of this function.
  */
 function isBuiltin(moduleName: string) {
-  const moduleNameWithoutPrefix = moduleName.startsWith('node:')
-    ? moduleName.slice(5)
-    : moduleName;
-
-  return builtinModules.includes(moduleNameWithoutPrefix);
+  return builtinModules.includes(moduleName.replace(/^node:/, ''));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { builtinModules } from 'node:module';
 
 import debug from 'debug'
 import type { FileSystem, ResolveOptions, Resolver } from 'enhanced-resolve'
@@ -8,7 +9,6 @@ import { hashObject } from 'eslint-module-utils/hash.js'
 import fg from 'fast-glob'
 import { createPathsMatcher, getTsconfig } from 'get-tsconfig'
 import type { TsConfigResult } from 'get-tsconfig'
-import isCore from 'is-core-module'
 import isGlob from 'is-glob'
 
 const { globSync } = fg
@@ -118,6 +118,19 @@ const digestHashObject = (value: object | null | undefined) =>
   hashObject(value ?? {}).digest('hex')
 
 /**
+ * Checks if a module is a core module
+ * module.isBuiltin is available in Node.js 16.17.0 or later. Once we drop support for older
+ * versions of Node.js, we can use module.isBuiltin instead of this function.
+ */
+function isBuiltin(moduleName: string) {
+  const moduleNameWithoutPrefix = moduleName.startsWith('node:')
+    ? moduleName.slice(5)
+    : moduleName;
+
+  return builtinModules.includes(moduleNameWithoutPrefix);
+}
+
+/**
  * @param source the module to resolve; i.e './some-module'
  * @param file the importing file's full path; i.e. '/usr/local/bin/file.js'
  * @param options
@@ -160,7 +173,7 @@ export function resolve(
   source = removeQuerystring(source)
 
   // don't worry about core node modules
-  if (isCore(source)) {
+  if (isBuiltin(source)) {
     log('matched core:', source)
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
+import { builtinModules } from 'node:module'
 import path from 'node:path'
-import { builtinModules } from 'node:module';
 
 import debug from 'debug'
 import type { FileSystem, ResolveOptions, Resolver } from 'enhanced-resolve'
@@ -123,7 +123,7 @@ const digestHashObject = (value: object | null | undefined) =>
  * versions of Node.js, we can use module.isBuiltin instead of this function.
  */
 function isBuiltin(moduleName: string) {
-  return builtinModules.includes(moduleName.replace(/^node:/, ''));
+  return builtinModules.includes(moduleName.replace(/^node:/, ''))
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,13 +3648,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/is-core-module@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@types/is-core-module@npm:2.2.2"
-  checksum: ceee36975a35e45da54973b64bc6d2757e01f6330c0db14ef73131562b397a28a92b387f811e9aa706e1cc02ce44a2720076e61d7c76aa7f54a92a778dcdbe6c
-  languageName: node
-  linkType: hard
-
 "@types/is-empty@npm:^1.0.0":
   version: 1.2.3
   resolution: "@types/is-empty@npm:1.2.3"
@@ -6118,7 +6111,6 @@ __metadata:
     "@mozilla/glean": "npm:^3.0.0"
     "@pkgr/rollup": "npm:^4.1.3"
     "@types/debug": "npm:^4.1.12"
-    "@types/is-core-module": "npm:^2.2.2"
     "@types/is-glob": "npm:^4.0.4"
     "@types/node": "npm:^18.19.39"
     "@types/unist": "npm:^2.0.10"
@@ -6131,7 +6123,6 @@ __metadata:
     eslint-plugin-import: "npm:eslint-plugin-i@^2.29.1"
     fast-glob: "npm:^3.3.2"
     get-tsconfig: "npm:^4.7.5"
-    is-core-module: "npm:^2.13.1"
     is-glob: "npm:^4.0.3"
     lint-staged: "npm:^13.3.0"
     npm-run-all2: "npm:^5.0.2"
@@ -7943,7 +7934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.12.1, is-core-module@npm:^2.13.0, is-core-module@npm:^2.13.1, is-core-module@npm:^2.5.0":
+"is-core-module@npm:^2.12.1, is-core-module@npm:^2.13.0, is-core-module@npm:^2.5.0":
   version: 2.13.1
   resolution: "is-core-module@npm:2.13.1"
   dependencies:


### PR DESCRIPTION
Node.js from v6.13.0, v8.10.0, v9.3.0 includes `module.builtinModules` which we can use to natively check if some module belongs to Node.js core or not.

This drops not one, but _three_ dependencies, removing 70 KB of bloat: https://npmgraph.js.org/?q=is-core-module