### PR TITLE
fix: fix prefix-only modules not marked as builtin

### DIFF
--- a/.changeset/red-giraffes-sleep.md
+++ b/.changeset/red-giraffes-sleep.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+fix: fix prefix-only Node.js modules not correctly recognized as builtin, a regression in v3.6.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ const digestHashObject = (value: object | null | undefined) =>
  * versions of Node.js, we can use module.isBuiltin instead of this function.
  */
 function isBuiltin(moduleName: string) {
-  return builtinModules.includes(moduleName.replace(/^node:/, ''))
+  return moduleName.startsWith('node:') || builtinModules.includes(moduleName)
 }
 
 /**


### PR DESCRIPTION
Following @ljharb's feedback in https://github.com/import-js/eslint-import-resolver-typescript/pull/295#issuecomment-2231939714, a different version of isBuiltin function has been implemented.