### PR TITLE
Release: use `npm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: yarn release
+          publish: npm publish
           commit: 'chore: release eslint-import-resolver-typescript'
           title: 'chore: release eslint-import-resolver-typescript'
         env:


### PR DESCRIPTION
Lastest release failed to be published: 
https://github.com/import-js/eslint-import-resolver-typescript/actions/runs/9928981640/job/27425949199

Based on this thread
https://stackoverflow.com/questions/64589655/package-is-not-publishing-to-npm-not-in-the-npm-registry

`npm publish` might work