### PR TITLE
fix(#303): use `@nolyfill/is-core-module`

### DIFF
--- a/.changeset/dirty-lobsters-behave.md
+++ b/.changeset/dirty-lobsters-behave.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+Fix resolve for `node:test`, `node:sea`, and `node:sqlite` without sacrificing installation size

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     }
   },
   "dependencies": {
+    "@nolyfill/is-core-module": "1.0.39",
     "debug": "^4.3.5",
     "enhanced-resolve": "^5.15.0",
     "eslint-module-utils": "^2.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
-import { builtinModules } from 'node:module'
 import path from 'node:path'
 
+import isNodeCoreModule from '@nolyfill/is-core-module'
 import debug from 'debug'
 import type { FileSystem, ResolveOptions, Resolver } from 'enhanced-resolve'
 import enhancedResolve from 'enhanced-resolve'
@@ -120,15 +120,6 @@ const digestHashObject = (value: object | null | undefined) =>
   hashObject(value ?? {}).digest('hex')
 
 /**
- * Checks if a module is a core module
- * module.isBuiltin is available in Node.js 16.17.0 or later. Once we drop support for older
- * versions of Node.js, we can use module.isBuiltin instead of this function.
- */
-function isBuiltin(moduleName: string) {
-  return builtinModules.includes(moduleName.replace(/^node:/, ''))
-}
-
-/**
  * @param source the module to resolve; i.e './some-module'
  * @param file the importing file's full path; i.e. '/usr/local/bin/file.js'
  * @param options
@@ -172,7 +163,7 @@ export function resolve(
 
   // don't worry about core node/bun modules
   if (
-    isBuiltin(source) ||
+    isNodeCoreModule(source) ||
     isBunModule(source, (process.versions.bun ?? 'latest') as Version)
   ) {
     log('matched core:', source)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@1stg/tsconfig/node16",
   "compilerOptions": {
     "module": "Node16",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
   "include": ["./src", "./shim.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nolyfill/is-core-module@npm:1.0.39":
+  version: 1.0.39
+  resolution: "@nolyfill/is-core-module@npm:1.0.39"
+  checksum: 0d6e098b871eca71d875651288e1f0fa770a63478b0b50479c99dc760c64175a56b5b04f58d5581bbcc6b552b8191ab415eada093d8df9597ab3423c8cac1815
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^2.0.0":
   version: 2.2.0
   resolution: "@npmcli/agent@npm:2.2.0"
@@ -6109,6 +6116,7 @@ __metadata:
     "@changesets/cli": "npm:^2.27.6"
     "@commitlint/cli": "npm:^17.8.1"
     "@mozilla/glean": "npm:^3.0.0"
+    "@nolyfill/is-core-module": "npm:1.0.39"
     "@pkgr/rollup": "npm:^4.1.3"
     "@types/debug": "npm:^4.1.12"
     "@types/is-glob": "npm:^4.0.4"


### PR DESCRIPTION
cc @wojtekmaj @SunsetTechuila

Closes #303.

Use `@nolyfill/is-core-module`.

`node:` prefix only module (`node:sea`, `node:test`) doesn't exist in `module.builtinModules`, and I want ESLint to detect typos like `node:slqite`. So we will have to maintain a data set.

The differences between `@nolyfill/is-core-module` and `is-core-module`:

- 0 dependency vs 1 dependency `hasown` (which then has a transitive dependency `function-bind`)
- Use `Set#has` instead of the `hasown` package
- Don't run the match against the Node.js version vs use the current Node.js version when not provided
- 2.7 KiB installation size vs 72 KiB installation size