### PR TITLE
Add .npmrc file back to restore deploys

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Deploys appear to have broken because https://github.com/import-js/eslint-import-resolver-typescript/commit/cecec359343a5b975e596dc11b9caae0455232aa#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35de deleted the `.npmrc`.

* Related issue: https://github.com/changesets/action/issues/98
* One repo's solution: https://github.com/pantheon-systems/decoupled-kit-js/pull/612/files (adds `.npmrc` to the repo)
* Another repo's solution: https://github.com/meilisearch/meilisearch-js-plugins/pull/983/files (adds `.npmrc` during CI run)

We _do_ have [`NPM_TOKEN` in the `env`](https://github.com/import-js/eslint-import-resolver-typescript/blob/c9b5626ee69bd529c7e391e40928a4fb28dce179/.github/workflows/release.yml#L44C11-L44C20), but we also need `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` in `.npmrc` by the time `changesets` runs.

Fixes #306