### PR TITLE
feat: implement import-x resolver interface v3

### DIFF
--- a/.changeset/metal-insects-trade.md
+++ b/.changeset/metal-insects-trade.md
@@ -1,0 +1,43 @@
+---
+'eslint-import-resolver-typescript': minor
+---
+
+This version has implemented the `eslint-plugin-import-x`'s v3 resolver interface. This allows you to use import/require to reference `eslint-import-resolver-typescript` directly in your ESLint flat config:
+
+**Previously**
+
+```js
+// eslint.config.js
+module.exports = {
+  settings: {
+    'import-x/resolver': {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+      // or
+      require.resolve('eslint-import-resolver-typescript'):
+        alwaysTryTypes: true,
+      }
+    }
+  }
+}
+```
+
+**Now**
+
+```js
+// eslint.config.js
+const {
+  createTypeScriptImportResolver,
+} = require('eslint-import-resolver-typescript')
+
+module.exports = {
+  settings: {
+    'import-x/resolver-next': [
+      createTypeScriptImportResolver({
+        alwaysTryTypes: true,
+      }),
+    ],
+  },
+}
+```

--- a/.changeset/metal-insects-trade.md
+++ b/.changeset/metal-insects-trade.md
@@ -41,3 +41,5 @@ module.exports = {
   },
 }
 ```
+
+Note that this only works with `eslint-plugin-import-x@>=4.5.0`. You can't use `createTypeScriptImportResolver` with the older versions of `eslint-plugin-import-x` or any existing versions of `eslint-plugin-import`.

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 dist
 lib
+tests
 CHANGELOG.md
 /shim.d.ts
 /pnpm-lock.yml

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 dist
 lib
-tests
 CHANGELOG.md
 /shim.d.ts
 /pnpm-lock.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.useFlatConfig": false
+}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,90 @@ yarn add -D eslint-plugin-import eslint-import-resolver-typescript
 
 ## Configuration
 
+### `eslint.config.js`
+
+If you are using `eslint-plugin-import-x@>=4.5.0`, you can use import/require to reference `eslint-import-resolver-typescript` directly in your ESLint flat config:
+
+```js
+// eslint.config.js
+const {
+  createTypeScriptImportResolver,
+} = require('eslint-import-resolver-typescript')
+
+module.exports = [{
+  settings: {
+    "import/resolver-next": [
+      createTypeScriptImportResolver({
+        alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+
+        // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
+
+        // use <root>/path/to/folder/tsconfig.json
+        project: "path/to/folder",
+
+        // Multiple tsconfigs (Useful for monorepos)
+
+        // use a glob pattern
+        project: "packages/*/tsconfig.json",
+
+        // use an array
+        project: [
+          "packages/module-a/tsconfig.json",
+          "packages/module-b/tsconfig.json"
+        ],
+
+        // use an array of glob patterns
+        project: [
+          "packages/*/tsconfig.json",
+          "other-packages/*/tsconfig.json"
+        ]
+      }),
+    ];
+  }
+}]
+```
+
+But if you are using `eslint-plugin-import` or the older version of `eslint-plugin-import-x`, you can't use require/import:
+
+```js
+// eslint.config.js
+module.exports = [
+  {
+    settings: {
+      'import/resolvers': {
+        typescript: {
+          alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+
+          // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
+
+          // use <root>/path/to/folder/tsconfig.json
+          project: 'path/to/folder',
+
+          // Multiple tsconfigs (Useful for monorepos)
+
+          // use a glob pattern
+          project: 'packages/*/tsconfig.json',
+
+          // use an array
+          project: [
+            'packages/module-a/tsconfig.json',
+            'packages/module-b/tsconfig.json',
+          ],
+
+          // use an array of glob patterns
+          project: [
+            'packages/*/tsconfig.json',
+            'other-packages/*/tsconfig.json',
+          ],
+        },
+      },
+    },
+  },
+]
+```
+
+### `.eslintrc`
+
 Add the following to your `.eslintrc` config:
 
 ```jsonc

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prepare": "simple-git-hooks",
     "release": "changeset publish",
     "test": "run-p 'test:*'",
+    "test:importXResolverV3": "eslint --config=tests/importXResolverV3/eslint.config.js tests/importXResolverV3",
     "test:multipleEslintrcs": "eslint --ext ts,tsx tests/multipleEslintrcs",
     "test:multipleTsconfigs": "eslint --ext ts,tsx tests/multipleTsconfigs",
     "test:withJsExtension": "node tests/withJsExtension/test.js && eslint --ext ts,tsx tests/withJsExtension",
@@ -78,13 +79,14 @@
     "@nolyfill/is-core-module": "1.0.39",
     "debug": "^4.3.7",
     "enhanced-resolve": "^5.15.0",
-    "eslint-module-utils": "^2.8.1",
     "fast-glob": "^3.3.2",
     "get-tsconfig": "^4.7.5",
     "is-bun-module": "^1.0.2",
-    "is-glob": "^4.0.3"
+    "is-glob": "^4.0.3",
+    "stable-hash": "^0.0.4"
   },
   "devDependencies": {
+    "@1stg/eslint-config": "7",
     "@1stg/lib-config": "^12.0.1",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.10",
@@ -99,6 +101,7 @@
     "eslint": "^8.57.1",
     "eslint-import-resolver-typescript": "link:.",
     "eslint-plugin-import": "npm:eslint-plugin-i@^2.29.1",
+    "eslint-plugin-import-x": "^4.5.0",
     "lint-staged": "^13.3.0",
     "npm-run-all2": "^5.0.2",
     "prettier": "^2.8.8",

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -1,4 +1,0 @@
-declare module 'eslint-module-utils/hash.js' {
-  import type { Hash } from 'node:crypto'
-  export const hashObject: (object: object, hash?: Hash) => Hash
-}

--- a/tests/importXResolverV3/eslint.config.js
+++ b/tests/importXResolverV3/eslint.config.js
@@ -1,0 +1,20 @@
+const path = require('path')
+const { createTypeScriptImportResolver } = require('../../lib/index.cjs')
+
+const globPattern = './packages/*/tsconfig.json'
+
+// in normal cases this is not needed because the __dirname would be the root
+const absoluteGlobPath = path.join(__dirname, globPattern)
+
+module.exports = {
+  ...require('eslint-plugin-import-x').flatConfigs.typescript,
+  settings: {
+    ...require('eslint-plugin-import-x').flatConfigs.typescript.settings,
+    'import-x/resolver-next': [
+      createTypeScriptImportResolver({
+        project: absoluteGlobPath,
+        alwaysTryTypes: true,
+      }),
+    ],
+  },
+}

--- a/tests/importXResolverV3/packages/module-a/index.ts
+++ b/tests/importXResolverV3/packages/module-a/index.ts
@@ -1,0 +1,15 @@
+// import relative
+import './tsImportee'
+import './tsxImportee'
+import './subfolder/tsImportee'
+import './subfolder/tsxImportee'
+
+// import using tsconfig.json path mapping
+import 'folder/tsImportee'
+import 'folder/tsxImportee'
+import 'folder/subfolder/tsImportee'
+import 'folder/subfolder/tsxImportee'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/importXResolverV3/packages/module-a/subfolder/tsImportee.ts
+++ b/tests/importXResolverV3/packages/module-a/subfolder/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/importXResolverV3/packages/module-a/subfolder/tsxImportee.tsx
+++ b/tests/importXResolverV3/packages/module-a/subfolder/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/importXResolverV3/packages/module-a/tsImportee.ts
+++ b/tests/importXResolverV3/packages/module-a/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/importXResolverV3/packages/module-a/tsconfig.json
+++ b/tests/importXResolverV3/packages/module-a/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react",
+    "paths": {
+      "folder/*": ["*"],
+      "*": ["../../../../node_modules/*"]
+    }
+  },
+  "files": ["index.ts", "tsImportee.ts", "tsxImportee.tsx"]
+}

--- a/tests/importXResolverV3/packages/module-a/tsxImportee.tsx
+++ b/tests/importXResolverV3/packages/module-a/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/importXResolverV3/packages/module-b/index.ts
+++ b/tests/importXResolverV3/packages/module-b/index.ts
@@ -1,0 +1,15 @@
+// import relative
+import './tsImportee'
+import './tsxImportee'
+import './subfolder/tsImportee'
+import './subfolder/tsxImportee'
+
+// import using tsconfig.json path mapping
+import 'folder/tsImportee'
+import 'folder/tsxImportee'
+import 'folder/subfolder/tsImportee'
+import 'folder/subfolder/tsxImportee'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/importXResolverV3/packages/module-b/subfolder/tsImportee.ts
+++ b/tests/importXResolverV3/packages/module-b/subfolder/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/importXResolverV3/packages/module-b/subfolder/tsxImportee.tsx
+++ b/tests/importXResolverV3/packages/module-b/subfolder/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/importXResolverV3/packages/module-b/tsImportee.ts
+++ b/tests/importXResolverV3/packages/module-b/tsImportee.ts
@@ -1,0 +1,1 @@
+export default 'yes'

--- a/tests/importXResolverV3/packages/module-b/tsconfig.json
+++ b/tests/importXResolverV3/packages/module-b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react",
+    "paths": {
+      "folder/*": ["*"],
+      "*": ["../../../../node_modules/*"]
+    }
+  },
+  "files": ["index.ts", "tsImportee.ts", "tsxImportee.tsx"]
+}

--- a/tests/importXResolverV3/packages/module-b/tsxImportee.tsx
+++ b/tests/importXResolverV3/packages/module-b/tsxImportee.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },
-  "include": ["./src", "./shim.d.ts"]
+  "include": ["./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,7 +76,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@1stg/eslint-config@npm:^7.0.1":
+"@1stg/eslint-config@npm:7, @1stg/eslint-config@npm:^7.0.1":
   version: 7.0.1
   resolution: "@1stg/eslint-config@npm:7.0.1"
   dependencies:
@@ -3881,6 +3881,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.17.0, @typescript-eslint/scope-manager@npm:^8.1.0":
+  version: 8.17.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.17.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.17.0"
+    "@typescript-eslint/visitor-keys": "npm:8.17.0"
+  checksum: fa934d9fd88070833c57a3e79c0f933d0b68884c00293a1d571889b882e5c9680ccfdc5c77a7160d5a4b8b46657f93db2468a4726a517fce4d3bc764b66f1995
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/type-utils@npm:5.62.0"
@@ -3905,6 +3915,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:8.17.0":
+  version: 8.17.0
+  resolution: "@typescript-eslint/types@npm:8.17.0"
+  checksum: 46baf69ab30dd814a390590b94ca64c407ac725cb0143590ddcaf72fa43c940cec180539752ce4af26ac7e0ae2f5f921cfd0d07b088ca680f8a28800d4d33a5f
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
@@ -3920,6 +3937,25 @@ __metadata:
     typescript:
       optional: true
   checksum: 06c975eb5f44b43bd19fadc2e1023c50cf87038fe4c0dd989d4331c67b3ff509b17fa60a3251896668ab4d7322bdc56162a9926971218d2e1a1874d2bef9a52e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.17.0":
+  version: 8.17.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.17.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.17.0"
+    "@typescript-eslint/visitor-keys": "npm:8.17.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8a1f8be767b82e75d41eedda7fdb5135787ceaab480671b6d9891b5f92ee3a13f19ad6f48d5abf5e4f2afc4dd3317c621c1935505ef098f22b67be2f9d01ab7b
   languageName: node
   linkType: hard
 
@@ -3941,6 +3977,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.1.0":
+  version: 8.17.0
+  resolution: "@typescript-eslint/utils@npm:8.17.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.17.0"
+    "@typescript-eslint/types": "npm:8.17.0"
+    "@typescript-eslint/typescript-estree": "npm:8.17.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: e82934468bece55ccf633be9f3fe6cae26791fa6488b5af08ea22566f6b32e1296917e46cb1fe39bba7717ebdf0dca49935112760c4439a11af36b3b7925917a
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -3948,6 +4001,16 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     eslint-visitor-keys: "npm:^3.3.0"
   checksum: dc613ab7569df9bbe0b2ca677635eb91839dfb2ca2c6fa47870a5da4f160db0b436f7ec0764362e756d4164e9445d49d5eb1ff0b87f4c058946ae9d8c92eb388
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.17.0":
+  version: 8.17.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.17.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.17.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: e7a3c3b9430ecefb8e720f735f8a94f87901f055c75dc8eec60052dfdf90cc28dd33f03c11cd8244551dc988bf98d1db9bd09ef8fd3c51236912cab3680b9c6b
   languageName: node
   linkType: hard
 
@@ -6152,6 +6215,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eslint-import-resolver-typescript@workspace:."
   dependencies:
+    "@1stg/eslint-config": "npm:7"
     "@1stg/lib-config": "npm:^12.0.1"
     "@changesets/changelog-github": "npm:^0.5.0"
     "@changesets/cli": "npm:^2.27.10"
@@ -6168,8 +6232,8 @@ __metadata:
     enhanced-resolve: "npm:^5.15.0"
     eslint: "npm:^8.57.1"
     eslint-import-resolver-typescript: "link:."
-    eslint-module-utils: "npm:^2.8.1"
     eslint-plugin-import: "npm:eslint-plugin-i@^2.29.1"
+    eslint-plugin-import-x: "npm:^4.5.0"
     fast-glob: "npm:^3.3.2"
     get-tsconfig: "npm:^4.7.5"
     is-bun-module: "npm:^1.0.2"
@@ -6181,6 +6245,7 @@ __metadata:
     simple-git-hooks: "npm:^2.11.1"
     size-limit: "npm:^11.0.0"
     size-limit-preset-node-lib: "npm:^0.3.0"
+    stable-hash: "npm:^0.0.4"
     type-coverage: "npm:^2.27.0"
     typescript: "npm:^5.3.2"
   peerDependencies:
@@ -6219,7 +6284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.8.0, eslint-module-utils@npm:^2.8.1":
+"eslint-module-utils@npm:^2.8.0":
   version: 2.8.1
   resolution: "eslint-module-utils@npm:2.8.1"
   dependencies:
@@ -6255,6 +6320,27 @@ __metadata:
   peerDependencies:
     eslint: ">=8"
   checksum: b0aa59e5a9fe034d6d485969091abfcdc6893bc0b9b145864d29307b03465141cc073bed806d9cb1a343a561362f2d0e9b34526af8fe8b7ca3cd8aa144f3720a
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-import-x@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "eslint-plugin-import-x@npm:4.5.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
+    debug: "npm:^4.3.4"
+    doctrine: "npm:^3.0.0"
+    eslint-import-resolver-node: "npm:^0.3.9"
+    get-tsconfig: "npm:^4.7.3"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.3"
+    semver: "npm:^7.6.3"
+    stable-hash: "npm:^0.0.4"
+    tslib: "npm:^2.6.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: c894408247344655f1f5db7c0d808ae5f7de331572968fa12074b54d490e6967cc5921f2ae616b161cafa171ff751c16bfd0201137fb47a1617105aabf5197d8
   languageName: node
   linkType: hard
 
@@ -6652,6 +6738,13 @@ __metadata:
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 3f357c554a9ea794b094a09bd4187e5eacd1bc0d0653c3adeb87962c548e6a1ab8f982b86963ae1337f5d976004146536dcee5d0e2806665b193fbfbf1a9231b
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-visitor-keys@npm:4.2.0"
+  checksum: 9651b3356b01760e586b4c631c5268c0e1a85236e3292bf754f0472f465bf9a856c0ddc261fceace155334118c0151778effafbab981413dbf9288349343fa25
   languageName: node
   linkType: hard
 
@@ -7355,6 +7448,15 @@ __metadata:
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: de7de5e4978354e8e6d9985baf40ea32f908a13560f793bc989930c229cc8d5c3f7b6b2896d8e43eb1a9b4e9e30018ef4b506752fd2a4b4d0dfee4af6841b119
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.3":
+  version: 4.8.1
+  resolution: "get-tsconfig@npm:4.8.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 3fb5a8ad57b9633eaea085d81661e9e5c9f78b35d8f8689eaf8b8b45a2a3ebf3b3422266d4d7df765e308cc1e6231648d114803ab3d018332e29916f2c1de036
   languageName: node
   linkType: hard
 
@@ -10114,6 +10216,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.4":
+  version: 9.0.5
+  resolution: "minimatch@npm:9.0.5"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
+  languageName: node
+  linkType: hard
+
 "minimist-options@npm:4.1.0":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -12806,6 +12917,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.6.0, semver@npm:^7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 36b1fbe1a2b6f873559cd57b238f1094a053dbfd997ceeb8757d79d1d2089c56d1321b9f1069ce263dc64cfa922fa1d2ad566b39426fe1ac6c723c1487589e10
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.6.2":
   version: 7.6.2
   resolution: "semver@npm:7.6.2"
@@ -13173,6 +13293,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 453f9a1c241c13f5dfceca2ab7b4687bcff354c3ccbc932f35452687b9ef0ccf8983fd13b8a3baa5844c1a4882d6e3ddff48b0e7fd21d743809ef33b80616d79
+  languageName: node
+  linkType: hard
+
+"stable-hash@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "stable-hash@npm:0.0.4"
+  checksum: 21c039d21c1cb739cf8342561753a5e007cb95ea682ccd452e76310bbb9c6987a89de8eda023e320b019f3e4691aabda75079cdbb7dadf7ab9013e931f2f23cd
   languageName: node
   linkType: hard
 
@@ -13623,6 +13750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-api-utils@npm:^1.3.0":
+  version: 1.4.3
+  resolution: "ts-api-utils@npm:1.4.3"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 713c51e7392323305bd4867422ba130fbf70873ef6edbf80ea6d7e9c8f41eeeb13e40e8e7fe7cd321d74e4864777329797077268c9f570464303a1723f1eed39
+  languageName: node
+  linkType: hard
+
 "ts-node@npm:^10.8.1, ts-node@npm:^10.9.1":
   version: 10.9.1
   resolution: "ts-node@npm:10.9.1"
@@ -13672,6 +13808,13 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.3":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #318.

Introduces support for flat config support and support for `eslint-plugin-import-x`'s v3 interface.

cc @mcshaman @melroy89 @Leonardo-Vieira-Andela

Also, README has been updated w/ the flat config usage.

-----

This version has implemented the `eslint-plugin-import-x`'s v3 resolver interface. This allows you to use import/require to reference `eslint-import-resolver-typescript` directly in your ESLint flat config:

**Previously**

```js
// eslint.config.js
module.exports = {
  settings: {
    'import-x/resolver': {
      typescript: {
        alwaysTryTypes: true,
      },
      // or
      require.resolve('eslint-import-resolver-typescript'):
        alwaysTryTypes: true,
      }
    }
  }
}
```

**Now**

```js
// eslint.config.js
const {
  createTypeScriptImportResolver,
} = require('eslint-import-resolver-typescript')

module.exports = {
  settings: {
    'import-x/resolver-next': [
      createTypeScriptImportResolver({
        alwaysTryTypes: true,
      }),
    ],
  },
}
```

Note that this only works with `eslint-plugin-import-x@>=4.5.0`. You can't use `createTypeScriptImportResolver` with the older versions of `eslint-plugin-import-x` or any existing versions of `eslint-plugin-import`.