### PR TITLE
fix: README has a wrong setting name 'import/resolvers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ But if you are using `eslint-plugin-import` or the older version of `eslint-plug
 module.exports = [
   {
     settings: {
-      'import/resolvers': {
+      'import/resolver': {
         typescript: {
           alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
 


### PR DESCRIPTION
This pr removes `s` from `import/resolvers` in flat-config's settings with `eslint-plugin-import` on README.md.

* According to [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file#typescript), the setting name seems to be `import/resolver`.
* With `.eslintrc`, README.md has already `import/resolver`.

## Background

With `import/resolvers` eslint shows these errors on my environment:

```
  4:37  error  Unable to resolve path to module '@/constants'                       import/no-unresolved
```

With `import/resolver`, no errors are shown.

### tsconfig.json

```json:tsconfig.json
{
  "extends": "./node_modules/@tsconfig/node20/tsconfig.json",
  "compilerOptions": {
    // ...
    "paths": {
      "@/*": ["./src/*"]
    }
  }
}
```

### foo.ts

```typescript:foo.ts
import { slackUserCacheTable } from '@/constants';
```