### PR TITLE
Resolves references in tsconfig.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -414,6 +414,8 @@ function initMappers(options: InternalResolverOptions) {
     ]),
   ]
 
+  const processedPaths = new Set<string>()
+
   mappers = projectPaths
     .flatMap(projectPath => {
       let tsconfigResult: TsConfigResult | null
@@ -428,8 +430,6 @@ function initMappers(options: InternalResolverOptions) {
       return getMapper(tsconfigResult)
     })
     .filter(isDefined)
-
-  const processedPaths = new Set<string>()
 
   function getMapper(tsconfigResult: TsConfigResult | null): Mapper[] {
     const list: Mapper[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,7 +447,6 @@ function initMappers(options: InternalResolverOptions) {
         .map(path => ({ path, config: parseTsconfig(path) }))
 
       for (const ref of references) {
-        processedPaths.add(ref.path)
         list.push(...getMapper(ref))
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,6 +438,8 @@ function initMappers(options: InternalResolverOptions) {
       return list
     }
 
+    processedPaths.add(tsconfigResult.path)
+
     if (tsconfigResult.config.references) {
       const references = tsconfigResult.config.references
         .map(ref => path.resolve(path.dirname(tsconfigResult.path), ref.path))


### PR DESCRIPTION
Fix #94. This pull request resolves the `references` field in `tsconfig.json` by recursively crawl all the files mentioned.

I don’t have time to write a test for this so contributors and maintainers are welcome to edit this pull request.