### PR TITLE
feat: if file has no corresponding mapper function, apply all of them…

### DIFF
--- a/.changeset/long-insects-tan.md
+++ b/.changeset/long-insects-tan.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+fix: if file has no corresponding mapper function, apply all of them, starting with the nearest one.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "./lib/index.js",
-    "limit": "3kB"
+    "limit": "3.1kB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:importXResolverV3": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint --config=tests/importXResolverV3/eslint.config.js tests/importXResolverV3",
     "test:multipleEslintrcs": "eslint --ext ts,tsx tests/multipleEslintrcs",
     "test:multipleTsconfigs": "eslint --ext ts,tsx tests/multipleTsconfigs",
+    "test:nearestTsconfig": "eslint --ext ts,tsx tests/nearestTsconfig",
     "test:withJsExtension": "node tests/withJsExtension/test.js && eslint --ext ts,tsx tests/withJsExtension",
     "test:withJsconfig": "eslint --ext js tests/withJsconfig",
     "test:withPaths": "eslint --ext ts,tsx tests/withPaths",

--- a/tests/nearestTsconfig/.eslintrc.cjs
+++ b/tests/nearestTsconfig/.eslintrc.cjs
@@ -1,0 +1,10 @@
+const path = require('node:path')
+
+const project = [
+  'tsconfig.json',
+  'a/tsconfig.json',
+  'a/b/tsconfig.json',
+  'a/b/c/tsconfig.json',
+].map(tsconfig => path.resolve(__dirname, tsconfig))
+
+module.exports = require('../baseEslintConfig.cjs')(project)

--- a/tests/nearestTsconfig/a/app/app.ts
+++ b/tests/nearestTsconfig/a/app/app.ts
@@ -1,0 +1,2 @@
+import 'components/a'
+import 'components/root'

--- a/tests/nearestTsconfig/a/b/app/app.ts
+++ b/tests/nearestTsconfig/a/b/app/app.ts
@@ -1,0 +1,2 @@
+import 'components/b'
+import 'components/root'

--- a/tests/nearestTsconfig/a/b/c/app/app.ts
+++ b/tests/nearestTsconfig/a/b/c/app/app.ts
@@ -1,0 +1,2 @@
+import 'components/c'
+import 'components/root'

--- a/tests/nearestTsconfig/a/b/c/components/c.ts
+++ b/tests/nearestTsconfig/a/b/c/components/c.ts
@@ -1,0 +1,1 @@
+export default 'c'

--- a/tests/nearestTsconfig/a/b/c/tsconfig.json
+++ b/tests/nearestTsconfig/a/b/c/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["../../../components/*", "./components/*"]
+    }
+  },
+  "files": ["components/c.ts"]
+}

--- a/tests/nearestTsconfig/a/b/components/b.ts
+++ b/tests/nearestTsconfig/a/b/components/b.ts
@@ -1,0 +1,1 @@
+export default 'b'

--- a/tests/nearestTsconfig/a/b/tsconfig.json
+++ b/tests/nearestTsconfig/a/b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["../../components/*", "./components/*"]
+    }
+  },
+  "files": ["components/b.ts"]
+}

--- a/tests/nearestTsconfig/a/components/a.ts
+++ b/tests/nearestTsconfig/a/components/a.ts
@@ -1,0 +1,1 @@
+export default 'a'

--- a/tests/nearestTsconfig/a/tsconfig.json
+++ b/tests/nearestTsconfig/a/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["../components/*", "./components/*"]
+    }
+  },
+  "files": ["components/a.ts"]
+}

--- a/tests/nearestTsconfig/app/app.ts
+++ b/tests/nearestTsconfig/app/app.ts
@@ -1,0 +1,1 @@
+import 'components/root'

--- a/tests/nearestTsconfig/components/root.ts
+++ b/tests/nearestTsconfig/components/root.ts
@@ -1,0 +1,1 @@
+export default 'root'

--- a/tests/nearestTsconfig/tsconfig.json
+++ b/tests/nearestTsconfig/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["./components/*"]
+    }
+  },
+  "files": ["components/root.ts"]
+}


### PR DESCRIPTION
FIX #363 

If file has no corresponding mapper function, apply all of them, starting with the nearest one.
Since the order is crucial here, I've deleted the intermediate `Set`