### PR TITLE
fix: include mapper with no files and force non-dynamic projects to use absolute paths

### DIFF
--- a/.changeset/new-peas-fry.md
+++ b/.changeset/new-peas-fry.md
@@ -1,0 +1,5 @@
+---
+'eslint-import-resolver-typescript': patch
+---
+
+fix: include mapper with no files and force non-dynamic projects to use absolute paths

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,9 @@ function initMappers(options: InternalResolverOptions) {
   // Turn glob patterns into paths
   const projectPaths = [
     ...new Set([
-      ...configPaths.filter(path => !isDynamicPattern(path)),
+      ...configPaths
+        .filter(p => !isDynamicPattern(p))
+        .map(p => path.resolve(process.cwd(), p)),
       ...globSync(
         configPaths.filter(path => isDynamicPattern(path)),
         {
@@ -503,11 +505,6 @@ function initMappers(options: InternalResolverOptions) {
                   })
                 : []),
             ]
-
-      if (files.length === 0) {
-        // eslint-disable-next-line unicorn/no-useless-undefined
-        return undefined
-      }
 
       return {
         path: toNativePathSeparator(tsconfigResult.path),


### PR DESCRIPTION
Fix #376 