### PR TITLE
fix: should prefer `module.isBuiltin` when `process.versions.bun` available

### DIFF
--- a/.changeset/light-kangaroos-kiss.md
+++ b/.changeset/light-kangaroos-kiss.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+fix: should prefer `module.isBuiltin` when `process.versions.bun` available

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,11 @@ export const resolve = (
 
   // don't worry about bun core modules
   if (bunVersion || options.bun) {
-    bunVersion ??= 'latest'
     if (
-      isBunModule(source, bunVersion) ||
-      isSupportedNodeModule(source, bunVersion)
+      bunVersion
+        ? module.isBuiltin(source)
+        : isBunModule(source, (bunVersion = 'latest')) ||
+          isSupportedNodeModule(source, bunVersion)
     ) {
       log('matched bun core:', source)
       return { found: true, path: null }


### PR DESCRIPTION
related https://github.com/import-js/eslint-import-resolver-typescript/pull/387#discussion_r1998588563

cc @SunsetTechuila