### PR TITLE
feat: make `is-bun-module` as optional peer dependency

### DIFF
--- a/.changeset/silent-cows-drive.md
+++ b/.changeset/silent-cows-drive.md
@@ -1,0 +1,12 @@
+---
+"eslint-import-resolver-typescript": minor
+---
+
+feat: make `is-bun-module` as optional peer dependency
+
+Technically this is a BREAKING CHANGE, but considering we just raise out v4 recently and this only affects `bun` users, `bun --bun eslint` even works without this dependency, so I'd consider this as a minor change.
+
+So for `bun` users, there are two options:
+
+1. install `is-bun-module` dependency manually and use `bun: true` option
+2. run `eslint` with `bun --bun eslint` w/o `bun: true` option

--- a/.changeset/silent-cows-drive.md
+++ b/.changeset/silent-cows-drive.md
@@ -10,4 +10,4 @@ So for `bun` users, there are three options:
 
 1. install `is-bun-module` dependency manually and use `bun: true` option
 2. run `eslint` with `bun --bun eslint` w/o `bun: true` option
-3. enable `run#bun` in [`bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun)
+3. enable `run#bun` in [`bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun) w/o `bun: true` option

--- a/.changeset/silent-cows-drive.md
+++ b/.changeset/silent-cows-drive.md
@@ -6,7 +6,8 @@ feat: make `is-bun-module` as optional peer dependency
 
 Technically this is a BREAKING CHANGE, but considering we just raise out v4 recently and this only affects `bun` users, `bun --bun eslint` even works without this dependency, so I'd consider this as a minor change.
 
-So for `bun` users, there are two options:
+So for `bun` users, there are three options:
 
 1. install `is-bun-module` dependency manually and use `bun: true` option
 2. run `eslint` with `bun --bun eslint` w/o `bun: true` option
+3. enable `run#bun` in [`bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun)

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "./lib/index.js",
-    "limit": "1.6kB"
+    "limit": "1.5kB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "peerDependencies": {
     "eslint": "*",
     "eslint-plugin-import": "*",
-    "eslint-plugin-import-x": "*"
+    "eslint-plugin-import-x": "*",
+    "is-bun-module": "*"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-import": {
@@ -73,12 +74,14 @@
     },
     "eslint-plugin-import-x": {
       "optional": true
+    },
+    "is-bun-module": {
+      "optional": true
     }
   },
   "dependencies": {
     "debug": "^4.4.0",
     "get-tsconfig": "^4.10.0",
-    "is-bun-module": "^1.3.0",
     "rspack-resolver": "^1.1.2",
     "stable-hash": "^0.0.5",
     "tinyglobby": "^0.2.12"
@@ -100,6 +103,7 @@
     "eslint": "^9.22.0",
     "eslint-import-resolver-typescript": "link:.",
     "eslint-plugin-import-x": "^4.8.0",
+    "is-bun-module": "^1.3.0",
     "lint-staged": "^15.5.0",
     "npm-run-all2": "^7.0.2",
     "prettier": "^3.5.3",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
+
+import type { IsBunModule } from './types.js'
 
 /**
  * For a scoped package, we must look in `@types/foo__bar` instead of `@types/@foo/bar`.
@@ -71,3 +74,17 @@ export const toGlobPath = (pathname: string) => pathname.replaceAll('\\', '/')
 
 export const toNativePath = (pathname: string) =>
   '/' === path.sep ? pathname : pathname.replaceAll('/', '\\')
+
+let isBunModule: IsBunModule | undefined
+
+const _filename = typeof __filename === 'string' ? __filename : import.meta.url
+
+const DEFAULT_BUN_VERSION = 'latest'
+
+export const isBunBuiltin = (source: string) => {
+  isBunModule ??= createRequire(_filename)('is-bun-module')
+  return (
+    isBunModule!.isBunModule(source, DEFAULT_BUN_VERSION) ||
+    isBunModule!.isSupportedNodeModule(source, DEFAULT_BUN_VERSION)
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   createFilesMatcher,
   parseTsconfig,
 } from 'get-tsconfig'
-import { type Version, isBunModule, isSupportedNodeModule } from 'is-bun-module'
+import { type Version } from 'is-bun-module'
 import { ResolverFactory } from 'rspack-resolver'
 import { stableHash } from 'stable-hash'
 
@@ -53,6 +53,11 @@ const oxcResolve = (
   }
 }
 
+type IsBunModule = typeof import('is-bun-module')
+let isBunModule: IsBunModule | undefined
+
+const _filename = typeof __filename === 'string' ? __filename : import.meta.url
+
 export const resolve = (
   source: string,
   file: string,
@@ -69,8 +74,10 @@ export const resolve = (
     if (
       bunVersion
         ? module.isBuiltin(source)
-        : isBunModule(source, (bunVersion = 'latest')) ||
-          isSupportedNodeModule(source, bunVersion)
+        : (isBunModule ??= module.createRequire(_filename)(
+            'is-bun-module',
+          ) as IsBunModule).isBunModule(source, (bunVersion = 'latest')) ||
+          isBunModule.isSupportedNodeModule(source, bunVersion)
     ) {
       log('matched bun core:', source)
       return { found: true, path: null }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,5 @@ export interface TypeScriptResolverOptions extends NapiResolveOptions {
   bun?: boolean
   noWarnOnMultipleProjects?: boolean
 }
+
+export type IsBunModule = typeof import('is-bun-module')

--- a/yarn.lock
+++ b/yarn.lock
@@ -6715,10 +6715,13 @@ __metadata:
     eslint: "*"
     eslint-plugin-import: "*"
     eslint-plugin-import-x: "*"
+    is-bun-module: "*"
   peerDependenciesMeta:
     eslint-plugin-import:
       optional: true
     eslint-plugin-import-x:
+      optional: true
+    is-bun-module:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
related https://github.com/import-js/eslint-import-resolver-typescript/pull/389#issuecomment-2729512493

Technically this is a BREAKING CHANGE, but considering we just raise out v4 recently and this only affects `bun` users, `bun --bun eslint` even works without this dependency, so I'd consider this as a minor change.

So for `bun` users, there are three options:

1. install `is-bun-module` dependency manually and use `bun: true` option
2. run `eslint` with `bun --bun eslint` w/o `bun: true` option
3. enable `run#bun` in [`bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun) w/o `bun: true` option

cc @SukkaW @SunsetTechuila 