### PR TITLE
Document usage with Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This means you can:
 - [Configuration](#configuration)
   - [`eslint.config.js`](#eslintconfigjs)
   - [`.eslintrc`](#eslintrc)
+  - [Other environments](#other-environments)
+    - [Bun](#bun)
 - [Options from `rspack-resolver`](#options-from-rspack-resolver)
   - [`conditionNames`](#conditionnames)
   - [`extensions`](#extensions)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export default [
         createTypeScriptImportResolver({
           alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
 
-          bun: true, // resolve Bun modules, defaults to false
+          bun: true, // resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
 
           // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 
@@ -140,7 +140,7 @@ export default [
         typescript: {
           alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
 
-          bun: true, // resolve Bun modules, defaults to false
+          bun: true, // resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
 
           // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 
@@ -192,7 +192,7 @@ Add the following to your `.eslintrc` config:
       "typescript": {
         "alwaysTryTypes": true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
 
-        "bun": true, // resolve Bun modules, defaults to false
+        "bun": true, // resolve Bun modules https://github.com/import-js/eslint-import-resolver-typescript#bun
 
         // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 
@@ -230,7 +230,7 @@ Add the following to your `.eslintrc` config:
 
 [Bun](https://bun.sh/) provides built-in modules such as `bun:test`, which are not resolved by default.
 
-Enable Bun built-in module resolution by choosing one of these 3 options:
+Enable Bun built-in module resolution by choosing 1 out of these 3 options:
 
 - Set the `bun: true` option, as shown in [Configuration](#configuration) above
 - Run ESLint with `bun --bun eslint`

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ Add the following to your `.eslintrc` config:
 
 #### Bun
 
-[Bun](https://bun.sh/) provides builtin modules such as `bun:test`, which are not resolved by default.
+[Bun](https://bun.sh/) provides built-in modules such as `bun:test`, which are not resolved by default.
 
-Enable Bun builtin module resolution by choosing one of these 3 options:
+Enable Bun built-in module resolution by choosing one of these 3 options:
 
 - Set the `bun: true` option, as shown in [Configuration](#configuration) above
 - Run ESLint with `bun --bun eslint`

--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ Add the following to your `.eslintrc` config:
 }
 ```
 
+### Other environments
+
+#### Bun
+
+[Bun](https://bun.sh/) provides builtin modules such as `bun:test`, which are not resolved by default.
+
+Enable Bun builtin module resolution by choosing one of these 3 options:
+
+- Set the `bun: true` option, as shown in [Configuration](#configuration) above
+- Run ESLint with `bun --bun eslint`
+- [Configure `run.bun` in `bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun)
+
 ## Options from [`rspack-resolver`][]
 
 ### `conditionNames`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ export default [
         createTypeScriptImportResolver({
           alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
 
+          bun: true, // resolve Bun modules, defaults to false
+
           // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 
           // use <root>/path/to/folder/tsconfig.json
@@ -135,6 +137,8 @@ export default [
       'import/resolver': {
         typescript: {
           alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+
+          bun: true, // resolve Bun modules, defaults to false
 
           // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 
@@ -185,6 +189,8 @@ Add the following to your `.eslintrc` config:
     "import/resolver": {
       "typescript": {
         "alwaysTryTypes": true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+
+        "bun": true, // resolve Bun modules, defaults to false
 
         // Choose from one of the "project" configs below or omit to use <root>/tsconfig.json by default
 


### PR DESCRIPTION
Hi @JounQin, hope you're well! 👋

I saw that the `bun` option from [`eslint-import-resolver-typescript@4.2.0`](https://github.com/import-js/eslint-import-resolver-typescript/releases/tag/v4.2.0) isn't documented in [the top level Configuration section in the readme](https://github.com/import-js/eslint-import-resolver-typescript#configuration)