### PR TITLE
feat: throw error on malformed tsconfig reference

### DIFF
--- a/.changeset/wise-singers-own.md
+++ b/.changeset/wise-singers-own.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": minor
+---
+
+feat: throw error on malformed `tsconfig` reference

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "./lib/index.js",
-    "limit": "1.4kB"
+    "limit": "1.5kB"
   }
 ]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,3 +73,5 @@ export const DEFAULT_TRY_PATHS = ['', ...DEFAULT_CONFIGS]
 export const MATCH_ALL = '**'
 
 export const DEFAULT_IGNORE = [MATCH_ALL, 'node_modules', MATCH_ALL].join('/')
+
+export const TSCONFIG_NOT_FOUND_REGEXP = /^Tsconfig not found\b/

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,11 @@ import { isBunBuiltin } from 'is-bun-module'
 import { stableHash } from 'stable-hash'
 import { ResolverFactory } from 'unrs-resolver'
 
-import { IMPORT_RESOLVER_NAME, JS_EXT_PATTERN } from './constants.js'
+import {
+  IMPORT_RESOLVER_NAME,
+  JS_EXT_PATTERN,
+  TSCONFIG_NOT_FOUND_REGEXP,
+} from './constants.js'
 import {
   mangleScopedPackage,
   removeQuerystring,
@@ -47,6 +51,9 @@ const unrsResolve = (
   }
   if (result.error) {
     log('oxc resolve error:', result.error)
+    if (TSCONFIG_NOT_FOUND_REGEXP.test(result.error)) {
+      throw new Error(result.error)
+    }
   }
   return {
     found: false,

--- a/tests/unit/malformed-reference/tsconfig.json
+++ b/tests/unit/malformed-reference/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "references": [
+    {
+      "path": "./non-existed"
+    }
+  ]
+}

--- a/tests/unit/unit.spec.ts
+++ b/tests/unit/unit.spec.ts
@@ -2,10 +2,15 @@ import path from 'node:path'
 
 import { exec } from 'tinyexec'
 
-import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
+import {
+  createTypeScriptImportResolver,
+  TSCONFIG_NOT_FOUND_REGEXP,
+} from 'eslint-import-resolver-typescript'
 
 describe('createTypeScriptImportResolver', async () => {
-  const pnpDir = path.resolve(import.meta.dirname, 'pnp')
+  const { dirname } = import.meta
+
+  const pnpDir = path.resolve(dirname, 'pnp')
 
   await exec('yarn', [], {
     nodeOptions: {
@@ -13,9 +18,9 @@ describe('createTypeScriptImportResolver', async () => {
     },
   })
 
-  const resolver = createTypeScriptImportResolver()
-
   it('should work with pnp', async () => {
+    const resolver = createTypeScriptImportResolver()
+
     const testfile = path.resolve(pnpDir, '__test__.js')
 
     expect(resolver.resolve('pnpapi', testfile)).toMatchInlineSnapshot(`
@@ -31,5 +36,17 @@ describe('createTypeScriptImportResolver', async () => {
           "path": "<ROOT>/tests/unit/pnp/.yarn/cache/lodash.zip-npm-4.2.0-5299417ec8-cb06530d81.zip/node_modules/lodash.zip/index.js",
         }
       `)
+  })
+
+  it('should error on malformed tsconfig reference', () => {
+    const project = path.resolve(dirname, 'malformed-reference')
+
+    const resolver = createTypeScriptImportResolver({ project })
+
+    const testfile = path.resolve(project, '__test__.js')
+
+    expect(() => resolver.resolve('index.js', testfile)).toThrowError(
+      TSCONFIG_NOT_FOUND_REGEXP,
+    )
   })
 })


### PR DESCRIPTION
close #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error handling now reports clear errors when an invalid TypeScript configuration is detected.
- **Tests**
  - Expanded test coverage to verify that malformed TypeScript configuration references trigger the appropriate error responses.
- **Chores**
  - Updated size limit for the file located at `./lib/index.js` from "1.4kB" to "1.5kB".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->