### PR TITLE
fix: add more extension aliases for ts source/declaration files

### DIFF
--- a/.changeset/late-elephants-confess.md
+++ b/.changeset/late-elephants-confess.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+fix: add more extension aliases for ts source/declaration files

--- a/README.md
+++ b/README.md
@@ -282,9 +282,19 @@ Default:
     ".d.ts",
     ".js",
   ],
+  ".ts": [".ts", ".d.ts", ".js"],
   ".jsx": [".tsx", ".d.ts", ".jsx"],
+  ".tsx": [
+    ".tsx",
+    ".d.ts",
+    ".jsx",
+    // `.tsx` can also be compiled as `.js`
+    ".js",
+  ],
   ".cjs": [".cts", ".d.cts", ".cjs"],
+  ".cts": [".cts", ".d.cts", ".cjs"],
   ".mjs": [".mts", ".d.mts", ".mjs"],
+  ".mts": [".mts", ".d.mts", ".mjs"],
 }
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,9 +36,19 @@ export const defaultExtensionAlias = {
     '.d.ts',
     '.js',
   ],
+  '.ts': ['.ts', '.d.ts', '.js'],
   '.jsx': ['.tsx', '.d.ts', '.jsx'],
+  '.tsx': [
+    '.tsx',
+    '.d.ts',
+    '.jsx',
+    // `.tsx` can also be compiled as `.js`
+    '.js',
+  ],
   '.cjs': ['.cts', '.d.cts', '.cjs'],
+  '.cts': ['.cts', '.d.cts', '.cjs'],
   '.mjs': ['.mts', '.d.mts', '.mjs'],
+  '.mts': ['.mts', '.d.mts', '.mjs'],
 }
 
 export const defaultMainFields = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const unrsResolve = (
     }
   }
   if (result.error) {
-    log('oxc resolve error:', result.error)
+    log('unrs-resolver error:', result.error)
     if (TSCONFIG_NOT_FOUND_REGEXP.test(result.error)) {
       throw new Error(result.error)
     }

--- a/tests/unit/unit.spec.ts
+++ b/tests/unit/unit.spec.ts
@@ -7,19 +7,19 @@ import {
   TSCONFIG_NOT_FOUND_REGEXP,
 } from 'eslint-import-resolver-typescript'
 
+const { dirname } = import.meta
+
 describe('createTypeScriptImportResolver', async () => {
-  const { dirname } = import.meta
-
-  const pnpDir = path.resolve(dirname, 'pnp')
-
-  await exec('yarn', [], {
-    nodeOptions: {
-      cwd: pnpDir,
-    },
-  })
+  const resolver = createTypeScriptImportResolver()
 
   it('should work with pnp', async () => {
-    const resolver = createTypeScriptImportResolver()
+    const pnpDir = path.resolve(dirname, 'pnp')
+
+    await exec('yarn', [], {
+      nodeOptions: {
+        cwd: pnpDir,
+      },
+    })
 
     const testfile = path.resolve(pnpDir, '__test__.js')
 
@@ -34,6 +34,19 @@ describe('createTypeScriptImportResolver', async () => {
       {
         "found": true,
         "path": "<ROOT>/tests/unit/pnp/.yarn/cache/lodash.zip-npm-4.2.0-5299417ec8-e596da80a6.zip/node_modules/lodash.zip/index.js",
+      }
+    `)
+  })
+
+  it('should resolve .d.ts with .ts extension', () => {
+    const dtsDir = path.resolve(dirname, 'dts')
+
+    const testfile = path.resolve(dtsDir, '__test__.js')
+
+    expect(resolver.resolve('./foo.ts', testfile)).toMatchInlineSnapshot(`
+      {
+        "found": true,
+        "path": "<ROOT>/tests/unit/dts/foo.d.ts",
       }
     `)
   })


### PR DESCRIPTION
close #429

cc @silverwind

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add more extension aliases for TypeScript files and update tests and logging accordingly.
> 
>   - **Extension Aliases**:
>     - Added more extension aliases for `.ts`, `.tsx`, `.cts`, and `.mts` in `src/constants.ts` and `README.md`.
>   - **Tests**:
>     - Added test in `unit.spec.ts` to verify `.d.ts` resolution with `.ts` extension.
>   - **Logging**:
>     - Updated log message in `unrsResolve()` in `src/index.ts` to correct resolver name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=import-js%2Feslint-import-resolver-typescript&utm_source=github&utm_medium=referral)<sup> for e371f47a0064bce78c901566555a49590c45ef0f. You can [customize](https://app.ellipsis.dev/import-js/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript import resolution by expanding support for extension aliases, ensuring better handling of `.ts`, `.tsx`, `.cts`, and `.mts` files and their declaration or compiled variants.

- **Documentation**
  - Updated documentation to clarify and list the new default extension alias mappings for TypeScript and related file types.

- **Tests**
  - Added and refactored tests to verify correct resolution of `.ts` imports to `.d.ts` files and improved test structure for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->