### PR TITLE
fix: remove buggy `module-sync` exports field

### DIFF
--- a/.changeset/rude-teachers-look.md
+++ b/.changeset/rude-teachers-look.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+fix: remove buggy `module-sync` exports field

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -8,4 +8,4 @@ patreon: 1stG
 custom:
   - https://opencollective.com/1stG
   - https://opencollective.com/rxts
-  - https://afdian.net/@JounQin
+  - https://afdian.com/a/JounQin

--- a/package.json
+++ b/package.json
@@ -23,17 +23,9 @@
         "types": "./lib/index.d.ts",
         "default": "./lib/index.js"
       },
-      "module-sync": {
-        "types": "./lib/index.d.ts",
-        "default": "./lib/index.js"
-      },
       "require": {
         "types": "./index.d.cts",
         "default": "./lib/index.cjs"
-      },
-      "default": {
-        "types": "./lib/index.d.ts",
-        "default": "./lib/index.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
https://github.com/nodejs/node/issues/57869

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove buggy `module-sync` export field from `package.json` and update URL in `.github/FUNDING.yml`.
> 
>   - **Exports**:
>     - Remove `module-sync` export field from `package.json` to fix a bug.
>   - **Funding**:
>     - Update URL in `.github/FUNDING.yml` from `https://afdian.net/@JounQin` to `https://afdian.com/a/JounQin`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=import-js%2Feslint-import-resolver-typescript&utm_source=github&utm_medium=referral)<sup> for 2568d85ecd908818b6359844fe4f75ff91e673e6. You can [customize](https://app.ellipsis.dev/import-js/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the funding link for "JounQin" to a new URL.
	- Added a changeset describing a patch update for a package.
- **Refactor**
	- Simplified export settings by removing unused export entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->