### PR TITLE
fix: check tsconfig matching before using resolver

### DIFF
--- a/.changeset/large-insects-kiss.md
+++ b/.changeset/large-insects-kiss.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+fix: check tsconfig matching before using resolver

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,11 +98,6 @@ export const resolve = (
     // must be an array with 2+ items here already ensured by `normalizeOptions`
     const projects = sortProjectsByAffinity(options.project as string[], file)
     for (const tsconfigPath of projects) {
-      const resolverCached = resolverCache.get(tsconfigPath)
-      if (resolverCached) {
-        resolver = resolverCached
-        break createResolver
-      }
       let tsconfigCached = tsconfigCache.get(tsconfigPath)
       if (!tsconfigCached) {
         tsconfigCache.set(
@@ -126,6 +121,13 @@ export const resolve = (
         continue
       }
       log('matched tsconfig at:', tsconfigPath, 'for', file)
+
+      const resolverCached = resolverCache.get(tsconfigPath)
+      if (resolverCached) {
+        resolver = resolverCached
+        break createResolver
+      }
+
       options = {
         ...options,
         tsconfig: {

--- a/tests/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/tests/e2e/__snapshots__/e2e.spec.ts.snap
@@ -64,6 +64,14 @@ exports[`e2e cases > should exec eslint successfully > multipleTsconfigs 1`] = `
 }
 `;
 
+exports[`e2e cases > should exec eslint successfully > multipleTsconfigsWithReferences 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
 exports[`e2e cases > should exec eslint successfully > nearestTsconfig 1`] = `
 {
   "exitCode": 0,

--- a/tests/e2e/multipleTsconfigsWithReferences/.eslintrc.cjs
+++ b/tests/e2e/multipleTsconfigsWithReferences/.eslintrc.cjs
@@ -1,0 +1,8 @@
+const path = require('node:path')
+
+const project = [
+  path.resolve(__dirname, 'tsconfig.node.json'),
+  path.resolve(__dirname, 'tsconfig.web.json'),
+]
+
+module.exports = require('../base.eslintrc.cjs')(project)

--- a/tests/e2e/multipleTsconfigsWithReferences/backend/index.ts
+++ b/tests/e2e/multipleTsconfigsWithReferences/backend/index.ts
@@ -1,0 +1,10 @@
+// import relative
+import './utils'
+
+// import using tsconfig path mapping
+import '@backend/utils'
+import '@shared/helper'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/e2e/multipleTsconfigsWithReferences/backend/utils.ts
+++ b/tests/e2e/multipleTsconfigsWithReferences/backend/utils.ts
@@ -1,0 +1,3 @@
+export const utilA = () => {
+  return 'backend utility'
+}

--- a/tests/e2e/multipleTsconfigsWithReferences/frontend/component.tsx
+++ b/tests/e2e/multipleTsconfigsWithReferences/frontend/component.tsx
@@ -1,0 +1,1 @@
+export default 'React Component'

--- a/tests/e2e/multipleTsconfigsWithReferences/frontend/index.tsx
+++ b/tests/e2e/multipleTsconfigsWithReferences/frontend/index.tsx
@@ -1,0 +1,10 @@
+// import relative
+import './component'
+
+// import using tsconfig path mapping
+import '@frontend/component'
+import '@shared/helper'
+
+// import from node_module
+import 'typescript'
+import 'dummy.js'

--- a/tests/e2e/multipleTsconfigsWithReferences/shared-utils/helper.ts
+++ b/tests/e2e/multipleTsconfigsWithReferences/shared-utils/helper.ts
@@ -1,0 +1,3 @@
+export const helperB = () => {
+  return 'shared helper'
+}

--- a/tests/e2e/multipleTsconfigsWithReferences/tsconfig.json
+++ b/tests/e2e/multipleTsconfigsWithReferences/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.web.json" }
+  ]
+}

--- a/tests/e2e/multipleTsconfigsWithReferences/tsconfig.node.json
+++ b/tests/e2e/multipleTsconfigsWithReferences/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@backend/*": ["backend/*"],
+      "@shared/*": ["shared-utils/*"]
+    }
+  },
+  "include": ["backend/**/*", "shared-utils/**/*"]
+}

--- a/tests/e2e/multipleTsconfigsWithReferences/tsconfig.web.json
+++ b/tests/e2e/multipleTsconfigsWithReferences/tsconfig.web.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@frontend/*": ["frontend/*"],
+      "@shared/*": ["shared-utils/*"]
+    }
+  },
+  "include": ["frontend/**/*", "shared-utils/**/*"]
+}


### PR DESCRIPTION
This PR fixes an issue where the resolver was using a cached resolver before determining which tsconfig file actually includes the current file when multiple tsconfig files are specified for the same directory path.

**Problem:**
When multiple tsconfig files (e.g., `tsconfig.node.json` and `tsconfig.web.json`) exist in the same directory with different `include` patterns, the cached resolver was used before matching which tsconfig includes the current file. This caused incorrect tsconfig settings to be applied.

**Solution:**
Reorder the resolver cache check to occur after tsconfig matching. This ensures the correct tsconfig configuration is identified before attempting to use a cached resolver.

**Changes:**
- Modified `src/index.ts` to move resolver cache check from lines 101-107 to after tsconfig matching (now at lines 133-139)
- Added e2e test case `multipleTsconfigsWithReferences`:
  - Backend files (`backend/**/*`) correctly use `tsconfig.node.json` with `@backend/*` paths
  - Frontend files (`frontend/**/*`) correctly use `tsconfig.web.json` with `@frontend/*` paths
  - Both configurations properly resolve shared utilities via `@shared/*` paths
- Updated test snapshots
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix resolver cache check order in `src/index.ts` to ensure correct tsconfig is identified before using cached resolver, with new e2e test added.
> 
>   - **Behavior**:
>     - Reorder resolver cache check in `resolve()` in `src/index.ts` to occur after tsconfig matching, ensuring correct tsconfig is identified before using cached resolver.
>   - **Tests**:
>     - Add e2e test `multipleTsconfigsWithReferences` to verify correct tsconfig usage for backend and frontend files.
>     - Backend files use `tsconfig.node.json` and frontend files use `tsconfig.web.json`, both resolving shared utilities via `@shared/*` paths.
>   - **Misc**:
>     - Update test snapshots to reflect new test case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=import-js%2Feslint-import-resolver-typescript&utm_source=github&utm_medium=referral)<sup> for 6697e04dcebea6aa36cb90eb35e5c80d08a1f1a5. You can [customize](https://app.ellipsis.dev/import-js/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Deferred resolver cache checks to improve lookup efficiency during configuration resolution.

* **Bug Fixes**
  * Fixed resolver selection when multiple TypeScript configurations are present so the correct resolver is used.

* **Tests**
  * Added end-to-end test coverage for projects with multiple TypeScript configs, path aliases, and project references.

* **Chores**
  * Added a changeset recording the patch release and fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->