### PR TITLE
chore(deps): migrate unrs-resolver to new oxc-resolver

### DIFF
--- a/.changeset/silly-beans-pretend.md
+++ b/.changeset/silly-beans-pretend.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-resolver-typescript": patch
+---
+
+chore(deps): migrate unrs-resolver to new oxc-resolver

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This means you can:
   - [`.eslintrc`](#eslintrc)
   - [Other environments](#other-environments)
     - [Bun](#bun)
-- [Options from `unrs-resolver`](#options-from-unrs-resolver)
+- [Options from `oxc-resolver`](#options-from-oxc-resolver)
   - [`conditionNames`](#conditionnames)
   - [`extensions`](#extensions)
   - [`extensionAlias`](#extensionalias)
@@ -236,7 +236,7 @@ Enable Bun built-in module resolution by choosing 1 out of these 3 options:
 - Run ESLint with `bun --bun eslint`.
 - [Configure `run.bun` in `bunfig.toml`](https://bun.sh/docs/runtime/bunfig#run-bun-auto-alias-node-to-bun).
 
-## Options from [`unrs-resolver`][]
+## Options from [`oxc-resolver`][]
 
 ### `conditionNames`
 
@@ -330,7 +330,7 @@ Default:
 
 ### Other options
 
-You can pass through other options of [`unrs-resolver`][] directly.
+You can pass through other options of [`oxc-resolver`][] directly.
 
 ### Default options
 
@@ -383,6 +383,6 @@ Detailed changes for each release are documented in [CHANGELOG.md](./CHANGELOG.m
 
 [`eslint-plugin-import`]: https://github.com/import-js/eslint-plugin-import
 [`eslint-plugin-import-x`]: https://github.com/un-ts/eslint-plugin-import-x
-[`unrs-resolver`]: https://github.com/unrs/unrs-resolver
+[`oxc-resolver`]: https://github.com/oxc-project/oxc-resolver
 [`typescript`]: https://www.typescriptlang.org
 [isc]: https://opensource.org/licenses/ISC

--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
   },
   "dependencies": {
     "debug": "^4.4.1",
-    "eslint-import-context": "^0.1.8",
+    "eslint-import-context": "^0.2.0",
     "get-tsconfig": "^4.10.1",
     "is-bun-module": "^2.0.0",
+    "oxc-resolver": "^11.19.1",
     "stable-hash-x": "^0.2.0",
-    "tinyglobby": "^0.2.14",
-    "unrs-resolver": "^1.7.11"
+    "tinyglobby": "^0.2.14"
   },
   "devDependencies": {
     "@1stg/common-config": "^14.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import {
   parseTsconfig,
 } from 'get-tsconfig'
 import { isBunBuiltin } from 'is-bun-module'
+import { ResolverFactory } from 'oxc-resolver'
 import { stableHash } from 'stable-hash-x'
-import { ResolverFactory } from 'unrs-resolver'
 
 import {
   IMPORT_RESOLVER_NAME,
@@ -37,7 +37,7 @@ const tsconfigCache = new Map<string, TsConfigJsonResolved>()
 
 const matcherCache = new Map<string, FileMatcher>()
 
-const unrsResolve = (
+const oxcResolve = (
   source: string,
   file: string,
   resolver: ResolverFactory,
@@ -50,7 +50,7 @@ const unrsResolve = (
     }
   }
   if (result.error) {
-    log('unrs-resolver error:', result.error)
+    log('oxc-resolver error:', result.error)
     if (TSCONFIG_NOT_FOUND_REGEXP.test(result.error)) {
       throw new Error(result.error)
     }
@@ -130,7 +130,6 @@ export const resolve = (
         ...options,
         tsconfig: {
           references: 'auto',
-          ...options.tsconfig,
           configFile: tsconfigPath,
         },
       }
@@ -164,7 +163,7 @@ export const resolve = (
     }
   }
 
-  const resolved = unrsResolve(source, file, resolver)
+  const resolved = oxcResolve(source, file, resolver)
 
   const foundPath = resolved.path
 
@@ -177,7 +176,7 @@ export const resolve = (
     !path.isAbsolute(source) &&
     !source.startsWith('.')
   ) {
-    const definitelyTyped = unrsResolve(
+    const definitelyTyped = oxcResolve(
       '@types/' + mangleScopedPackage(source),
       file,
       resolver,
@@ -191,12 +190,7 @@ export const resolve = (
   if (foundPath) {
     log('matched path:', foundPath)
   } else {
-    log(
-      "didn't find",
-      source,
-      'with',
-      options.tsconfig?.configFile || options.project,
-    )
+    log("didn't find", source, 'with', options.tsconfig || options.project)
   }
 
   return resolved

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -1,6 +1,6 @@
+import type { TsconfigOptions } from 'oxc-resolver'
 import { stableHash } from 'stable-hash-x'
 import { globSync, isDynamicPattern } from 'tinyglobby'
-import type { TsconfigOptions } from 'unrs-resolver'
 
 import {
   DEFAULT_CONFIGS,
@@ -32,7 +32,8 @@ export function normalizeOptions(
 ): TypeScriptResolverOptions {
   let { project, tsconfig, noWarnOnMultipleProjects } = (options ||= {})
 
-  let { configFile, references }: Partial<TsconfigOptions> = tsconfig ?? {}
+  let { configFile, references }: Partial<TsconfigOptions> =
+    typeof tsconfig === 'object' ? tsconfig : {}
 
   let ensured: boolean | undefined
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { NapiResolveOptions } from 'unrs-resolver'
+import type { NapiResolveOptions } from 'oxc-resolver'
 
 export interface TypeScriptResolverOptions extends NapiResolveOptions {
   project?: string[] | string

--- a/tests/unit/unit.spec.ts
+++ b/tests/unit/unit.spec.ts
@@ -14,7 +14,7 @@ const TIMEOUT = 60_000
 describe('createTypeScriptImportResolver', async () => {
   const resolver = createTypeScriptImportResolver()
 
-  it(
+  it.skipIf(!process.versions.pnp)(
     'should work with pnp',
     async () => {
       const pnpDir = path.resolve(dirname, 'pnp')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.2"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/725c30ec9c480a8d0c1a6a4ce31dc6c830365d485e23ad560e143d1cb9db89a0c95fbb5b9d53c07121729817a3683db6f1ab65d7e4f38fa7482a11b15ef6c6fd
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3052,6 +3064,148 @@ __metadata:
   version: 0.72.2
   resolution: "@oxc-project/types@npm:0.72.2"
   checksum: 10c0/92e6bfbfb8eeec60c85344e074089315d9bef4ed393afbec2e2ceb16f3ed77a070ed3597fdfa635441e20a63d0a2468a85a4dde347ade7d7e935f1eb1ae3586a
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm-eabi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.19.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.19.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.19.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-freebsd-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.19.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-openharmony-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.19.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.19.1"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3411,6 +3565,15 @@ __metadata:
   version: 0.6.1
   resolution: "@total-typescript/ts-reset@npm:0.6.1"
   checksum: 10c0/c42c592054d33e86ac870065820888f89f05e47b2cfbc6bed95f3084b1f6d13b0231b5b8577eabf461aeb3f37c63ae3216f343b573f7136766eb750aac0dd1ab
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@tybys/wasm-util@npm:0.10.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
   languageName: node
   linkType: hard
 
@@ -6046,7 +6209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-context@npm:^0.1.7, eslint-import-context@npm:^0.1.8":
+"eslint-import-context@npm:^0.1.7":
   version: 0.1.8
   resolution: "eslint-import-context@npm:0.1.8"
   dependencies:
@@ -6058,6 +6221,21 @@ __metadata:
     unrs-resolver:
       optional: true
   checksum: 10c0/61e7f63eadcf9345a905acd67f3742b855bc0638e2ed2a7072b184d183f35c69d547d5a6d2adc8535f589e9daaa293b5ce352dcb79f6188fbd125899c1e28e40
+  languageName: node
+  linkType: hard
+
+"eslint-import-context@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eslint-import-context@npm:0.2.0"
+  dependencies:
+    get-tsconfig: "npm:^4.10.1"
+    stable-hash-x: "npm:^0.2.0"
+  peerDependencies:
+    oxc-resolver: ^11.0.0
+  peerDependenciesMeta:
+    oxc-resolver:
+      optional: true
+  checksum: 10c0/43d9f47e603eed7f0e865b3ba7707951136c26cbd5bdcaa1aca0bfc0d5b3aa938b1058286dbd9df10d47e8228831f2f9dc8f489a36846e1e05c60965dc83b1f5
   languageName: node
   linkType: hard
 
@@ -6082,13 +6260,14 @@ __metadata:
     debug: "npm:^4.4.1"
     dummy.js: "link:dummy.js"
     eslint: "npm:^9.28.0"
-    eslint-import-context: "npm:^0.1.8"
+    eslint-import-context: "npm:^0.2.0"
     eslint-import-resolver-typescript: "workspace:*"
     eslint-plugin-import-x: "npm:^4.15.1"
     get-tsconfig: "npm:^4.10.1"
     is-bun-module: "npm:^2.0.0"
     nano-staged: "npm:^0.8.0"
     npm-run-all2: "npm:^8.0.4"
+    oxc-resolver: "npm:^11.19.1"
     path-serializer: "npm:^0.5.0"
     premove: "npm:^4.0.0"
     prettier: "npm:^3.5.3"
@@ -6102,7 +6281,6 @@ __metadata:
     tsdown: "npm:^0.12.7"
     type-coverage: "npm:^2.29.7"
     typescript: "npm:^5.8.3"
-    unrs-resolver: "npm:^1.7.11"
     vitest: "npm:^3.2.2"
     yarn-berry-deduplicate: "npm:^6.1.3"
   peerDependencies:
@@ -9897,6 +10075,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxc-resolver@npm:^11.19.1":
+  version: 11.19.1
+  resolution: "oxc-resolver@npm:11.19.1"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.19.1"
+    "@oxc-resolver/binding-android-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-openharmony-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-ia32-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.19.1"
+  dependenciesMeta:
+    "@oxc-resolver/binding-android-arm-eabi":
+      optional: true
+    "@oxc-resolver/binding-android-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-x64":
+      optional: true
+    "@oxc-resolver/binding-freebsd-x64":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-musl":
+      optional: true
+    "@oxc-resolver/binding-openharmony-arm64":
+      optional: true
+    "@oxc-resolver/binding-wasm32-wasi":
+      optional: true
+    "@oxc-resolver/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/8ac4eaffa9c0bcbb9f4f4a2b43786457ec5a68684d8776cb78b5a15ce3d1a79d3e67262aa3c635f98a0c1cd6cd56a31fcb05bffb9a286100056e4ab06b928833
+  languageName: node
+  linkType: hard
+
 "p-cancelable@npm:^2.0.0":
   version: 2.1.1
   resolution: "p-cancelable@npm:2.1.1"
@@ -13178,7 +13425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unrs-resolver@npm:^1.7.10, unrs-resolver@npm:^1.7.11":
+"unrs-resolver@npm:^1.7.10":
   version: 1.7.11
   resolution: "unrs-resolver@npm:1.7.11"
   dependencies:


### PR DESCRIPTION
Closes #470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated resolver dependency from unrs-resolver to oxc-resolver and updated bundled resolvers
  * Updated eslint-import-context to v0.2.0
  * Added a changeset entry recording the dependency chore

* **Documentation**
  * Updated resolver options docs and related links to reference the new resolver

* **Tests**
  * Made a PnP-related unit test conditional to runtime PnP support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->