### PR TITLE
docs: document resolver option defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,15 @@ You can pass through other options of [`unrs-resolver`][] directly.
 
 You can reuse `defaultConditionNames`, `defaultExtensions`, `defaultExtensionAlias`, and `defaultMainFields` by directly using `require`/`import`.
 
+Resolver-specific options use these defaults:
+
+| Option                     | Default                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| `project`                  | The first available `tsconfig.json` or `jsconfig.json` in the current working directory |
+| `alwaysTryTypes`           | `true`                                                                                  |
+| `bun`                      | Enabled automatically when running under Bun; otherwise `false`                         |
+| `noWarnOnMultipleProjects` | `false` (warn when an explicit `project` resolves to multiple files)                    |
+
 ## Contributing
 
 - Make sure your change is covered by a test import.


### PR DESCRIPTION
## Summary

- document the resolver-specific defaults for `project`, `alwaysTryTypes`, `bun`, and `noWarnOnMultipleProjects`
- keep the existing `unrs-resolver` default collections and pass-through options unchanged

Closes #430.

## Validation

- `yarn build`
- `yarn lint`
- `yarn typecov` (843/843, 100%)
- `yarn prettier --check README.md`
- `yarn test`: all 16 end-to-end cases pass; the unit file cannot resolve the Vitest source alias when the local checkout path contains a space, before test collection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Default options” table documenting resolver-specific default option values for `project`, `alwaysTryTypes`, `bun`, and `noWarnOnMultipleProjects`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->